### PR TITLE
Add eslint rule for param reassign

### DIFF
--- a/generator/template/default/_eslintrc.js
+++ b/generator/template/default/_eslintrc.js
@@ -15,6 +15,10 @@ module.exports = {
     }],
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-param-reassign': ['error', {
+      props: true,
+      ignorePropertyModificationsFor: ['state'],
+    }],
   },
   parserOptions: {
     parser: 'babel-eslint',


### PR DESCRIPTION
Since we are using mutations to change state and state is first function parameter, eslint will give us warning about parameter assignment.
Instead of adding comments like 
```language=javascript
/* eslint-disable no-param-reassign */
```
we can add rule to ignore property modification on `state` parameter.