### PR TITLE
Add box model as default

### DIFF
--- a/generator/template/default/src/App.vue
+++ b/generator/template/default/src/App.vue
@@ -16,6 +16,13 @@ export default {
 </script>
 
 <style lang="scss">
+html,
+body {
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
 #app {
   font-family: Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
Adds default box sizing to `border-box` and removes default margin and padding.