### PR TITLE
Add prompt and templates for gravity gateway

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -76,6 +76,18 @@ module.exports = (api, options, rootOptions) => {
     }
   });
 
+  if (options.sevenGravityGateway) {
+    api.extendPackage({
+      dependencies: {
+        "@nsoft/seven-gravity-gateway": "^1.10.1"
+      }
+    });
+
+    api.render('./template/seven-gravity-gateway', {
+      ...options,
+    });
+  }
+
   api.render('./template/default', {
     ...options,
   });

--- a/generator/template/seven-gravity-gateway/src/plugins/seven-gravity-gateway/master.js
+++ b/generator/template/seven-gravity-gateway/src/plugins/seven-gravity-gateway/master.js
@@ -1,0 +1,1 @@
+import GatewayMaster from '@nsoft/seven-gravity-gateway/master';

--- a/generator/template/seven-gravity-gateway/src/plugins/seven-gravity-gateway/slave.js
+++ b/generator/template/seven-gravity-gateway/src/plugins/seven-gravity-gateway/slave.js
@@ -1,0 +1,1 @@
+import GatewaySlave from '@nsoft/seven-gravity-gateway/slave';

--- a/prompts.js
+++ b/prompts.js
@@ -18,4 +18,10 @@ module.exports = [
     message: 'Author',
     default: 'NSoft',
   },
+  {
+    name: 'sevenGravityGateway',
+    type: 'confirm',
+    message: 'Do you want to include Seven Gravity Gateway',
+    default: false
+  },
 ]


### PR DESCRIPTION
- it will prompt user to include gravity gateway
- if yes it will add two files (`master.js` and `slave.js`) to `plugins/seven-gravity-gateway`
- not sure if "dash" is valid naming convention (?)